### PR TITLE
Feature/migrate wait

### DIFF
--- a/commands/MigrateController.php
+++ b/commands/MigrateController.php
@@ -397,7 +397,7 @@ EOT;
 	 * @param int $interval -- seconds between connection attempts
 	 * @return int -- 0 on success, 1 otherwise
 	 */
-	public function actionWait($timeout=60, $interval=2) {
+	public function actionWait($timeout=60, $interval=5) {
 		$result = AppHelper::waitFor(function() use ($interval) {
 			try {
 				echo "Trying to connect...\n";

--- a/commands/MigrateController.php
+++ b/commands/MigrateController.php
@@ -397,13 +397,12 @@ EOT;
 	 * @param int $interval -- seconds between connection attempts
 	 * @return int -- 0 on success, 1 otherwise
 	 */
-	public function actionWait($timeout=60, $interval=5) {
+	public function actionWait($timeout=60, $interval=2) {
 		$result = AppHelper::waitFor(function() use ($interval) {
 			try {
 				echo "Trying to connect...\n";
-				sleep($interval);
-				//$this->app->db->connectNow(); // TODO
-				//echo "Connected\n";
+				if(!$this->app->db->pdo) return false;
+				echo "Connected\n";
 				return true;
 			}
 			catch(Throwable $e) {

--- a/lib/App.php
+++ b/lib/App.php
@@ -714,7 +714,7 @@ class App extends Component {
 
     public static function cli($configFile) {
         try {
-			if(!file_exists($configFile)) throw new Exception("Configfile at '$configFile' is missing.");
+			if(!file_exists($configFile)) throw new Exception("Config file at '$configFile' is missing.");
             $config = include $configFile;
             defined('ENV') || define('ENV', $config['application_env'] ?? 'production');
             defined('ENV_DEV') || define('ENV_DEV', ENV != 'production');

--- a/lib/AppHelper.php
+++ b/lib/AppHelper.php
@@ -456,12 +456,14 @@ class AppHelper {
 	 * See usage example in {@see MigrateController::actionWait()}
 	 *
 	 * @param Closure $test -- test to run. Must return truthy value on success
-	 * @param int $timeout -- seconds to giving up waiting
-	 * @param int $interval -- seconds between retry attempts
+	 * @param int $timeout -- seconds to giving up waiting, the minimum allowed value is 1
+	 * @param int $interval -- seconds between retry attempts, the minimum allowed value is 1
 	 * @return bool -- true if test succeeded within timeout, false otherwise
 	 */
 	public static function waitFor($test, $timeout=60, $interval=1) {
 		$startTime = time();
+		$interval = max(1, $interval);
+		$timeout = max(1, $timeout);
 		$timeoutPassed = $startTime+$timeout;
 		do {
 			$lastTry = time();

--- a/lib/AppHelper.php
+++ b/lib/AppHelper.php
@@ -462,12 +462,13 @@ class AppHelper {
 	 */
 	public static function waitFor($test, $timeout=60, $interval=1) {
 		$startTime = time();
+		$timeoutPassed = $startTime+$timeout;
 		do {
 			$lastTry = time();
 			if($test()) return true;
-			while(time() < $lastTry+$interval && time() < $startTime+$timeout) sleep(1);
+			sleep(min($timeoutPassed - time(), $lastTry+$interval - time()));
 		}
-		while(time() < $startTime+$timeout);
+		while(time() < $timeoutPassed);
 		return false;
 	}
 

--- a/lib/AppHelper.php
+++ b/lib/AppHelper.php
@@ -453,10 +453,7 @@ class AppHelper {
 	/**
 	 * Waits for a test to satisfy (i.e. to return a truthy value)
 	 *
-	 * Note: `$interval` timeout is checked before `$timeout` timeout, so the latter will not be detected until the first one takes place
-	 * (e.g. when `$interval` is greater than `$timeout`)
-	 *
-	 * Warning: this function is experimental, usage example and unit test is coming soon
+	 * See usage example in {@see MigrateController::actionWait()}
 	 *
 	 * @param Closure $test -- test to run. Must return truthy value on success
 	 * @param int $timeout -- seconds to giving up waiting
@@ -468,7 +465,7 @@ class AppHelper {
 		do {
 			$lastTry = time();
 			if($test()) return true;
-			while(time() < $lastTry+$interval) sleep(1);
+			while(time() < $lastTry+$interval && time() < $startTime+$timeout) sleep(1);
 		}
 		while(time() < $startTime+$timeout);
 		return false;

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -50,12 +50,13 @@ abstract class Connection extends Component {
     protected $_user, $_password;
 
     /**
-     * Must reset the connection to the standard state (e.g. Quote mode)
+     * Must reset the connection to the standard state (e.g. Quote mode).
+     * Must use `_pdo` property instead of `pdo`.
      *
      * @return bool
      * @throws Exception
      */
-    abstract public function reset();
+    abstract protected function reset();
 
 	/**
 	 * Check if a table exists in the current database.
@@ -359,9 +360,14 @@ abstract class Connection extends Component {
 	 */
 	public function getPdo() {
 		if(!$this->_pdo) {
-			$this->_pdo = new PDO($this->dsn, $this->_user, $this->_password);
-			$this->_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-			$this->reset();
+			try {
+				$this->_pdo = new PDO($this->dsn, $this->_user, $this->_password);
+				$this->_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+				$this->reset();
+			}
+			catch(\Throwable $e) {
+				throw new Exception('Connection failed', 0, $e);
+			}
 		}
 		return $this->_pdo;
 	}

--- a/lib/MysqlConnection.php
+++ b/lib/MysqlConnection.php
@@ -14,16 +14,6 @@ use PDOStatement;
  * @package UMVC Simple Application Framework
  */
 class MysqlConnection extends Connection {
-
-    /**
-     * @throws Exception
-     */
-    public function init() {
-        $this->pdo = new PDO($this->dsn, $this->_user, $this->_password);
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $this->reset();
-    }
-
     public function supportsOrderNullsLast() { return false; }
 
     /**

--- a/lib/MysqlConnection.php
+++ b/lib/MysqlConnection.php
@@ -23,6 +23,7 @@ class MysqlConnection extends Connection {
      * @throws Exception on failure
      */
     protected function reset() {
+		// Note: _pdo must be used here, because reset() is used within pdo getter.
         $status = $this->_pdo->query("SET SQL_MODE='ANSI_QUOTES,NO_AUTO_VALUE_ON_ZERO'");
         if($status===false) throw new Exception("Error resetting the connection. ".implode(';', $this->_pdo->errorInfo()));
         return true;

--- a/lib/MysqlConnection.php
+++ b/lib/MysqlConnection.php
@@ -18,13 +18,13 @@ class MysqlConnection extends Connection {
 
     /**
      * Resets the connection to standard mode.
-     * Set MySQL to SQL-92 standard tableName/fieldName quoting. The backtick quoting is still valid
+     * Set MySQL to SQL-92 standard tableName/fieldName quoting. The backtick quoting is still valid.
      *
      * @throws Exception on failure
      */
-    public function reset() {
-        $status = $this->pdo->query("SET SQL_MODE='ANSI_QUOTES,NO_AUTO_VALUE_ON_ZERO'");
-        if($status===false) throw new Exception("Error resetting the connection. ".implode(';', $this->pdo->errorInfo()));
+    protected function reset() {
+        $status = $this->_pdo->query("SET SQL_MODE='ANSI_QUOTES,NO_AUTO_VALUE_ON_ZERO'");
+        if($status===false) throw new Exception("Error resetting the connection. ".implode(';', $this->_pdo->errorInfo()));
         return true;
     }
 

--- a/lib/Query.php
+++ b/lib/Query.php
@@ -1277,8 +1277,7 @@ class Query extends Component
      *
      * @return string
      * @throws Exception
-     * @see buildExpression
-     *
+     * @see Query::buildExpression
      */
     public function buildWhere($alias=null) {
         $condition = $this->_where;

--- a/readme.md
+++ b/readme.md
@@ -116,12 +116,17 @@ A built-in dockerized testing environment can be used to test with different php
 1. configure the needed database version in `tests/docker-compose.yml` (make clones of this template file)  
 2. configure the php version in `tests/docker/Dockerfile` (extension installation steps may change)
 3. configure the used ports and base-url in `tests/.env`
-4. build the stack using `docker compose up --build -d` (in the tests dir)
+4. build the stack using `docker compose up --build -d` (in the `tests` dir)
 5. your php container should now be 'umvc-php-1'
 6. run unit tests with `docker exec -it umvc-php-1 php vendor/bin/codecept run unit`
 
 Change log
 ----------
+### Next
+
+- migrate/wait command added
+- postponed connection of Connection
+
 ### Version 1.3 -- 2022-12-03
 
 - Migration SQL transaction issues

--- a/tests/.env
+++ b/tests/.env
@@ -6,7 +6,7 @@ HTTP_PORT=7070
 MYSQL_PORT=7072
 TIMEZONE=Europe/Berlin
 
-APPLICATION_ENV=local
+APPLICATION_ENV=develop
 # Alternative to set real external base url
 APP_BASEURL="http://umvc.local"
 # FQDN Server name for apache web server and default certificate

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -32,8 +32,7 @@ fi
 cd $APPDIR
 
 echo "Waiting for database container to be ready..."
-sleep 5
-#php app migrate/wait || echo "Timeout connecting to database." # TODO
+php app migrate/wait || echo "Timeout connecting to database."
 
 echo "Migrating database"
 php app migrate confirm=yes

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -3,8 +3,6 @@
 echo "initializing the container"
 echo "=========================="
 
-set -o
-
 APPDIR=/app/tests/_data/testapp
 RUNTIMEDIR=/app/tests/_output
 

--- a/tests/docker/readme.md
+++ b/tests/docker/readme.md
@@ -1,0 +1,96 @@
+Example of docker container initialization log, how `php app migrate/wait` in `entrypoint.sh` affects the startup.
+```
+2022-12-03 18:50:44 umvc-php-1      | initializing the container
+2022-12-03 18:50:44 umvc-php-1      | ==========================
+2022-12-03 18:50:45 umvc-php-1      | Loading composer repositories with package information
+2022-12-03 18:50:45 umvc-php-1      | Info from https://repo.packagist.org: #StandWithUkraine
+2022-12-03 18:50:47 umvc-php-1      | Updating dependencies
+2022-12-03 18:50:47 umvc-php-1      | Nothing to modify in lock file
+2022-12-03 18:50:47 umvc-php-1      | Installing dependencies from lock file (including require-dev)
+2022-12-03 18:50:47 umvc-php-1      | Nothing to install, update or remove
+2022-12-03 18:50:47 umvc-php-1      | Package simplesamlphp/simplesamlphp-module-authfacebook is abandoned, you should avoid using it. No replacement was suggested.
+2022-12-03 18:50:47 umvc-php-1      | Package simplesamlphp/simplesamlphp-module-authwindowslive is abandoned, you should avoid using it. No replacement was suggested.
+2022-12-03 18:50:47 umvc-php-1      | Package simplesamlphp/simplesamlphp-module-oauth is abandoned, you should avoid using it. No replacement was suggested.
+2022-12-03 18:50:47 umvc-php-1      | Package simplesamlphp/simplesamlphp-module-riak is abandoned, you should avoid using it. No replacement was suggested.
+2022-12-03 18:50:47 umvc-php-1      | Package twig/extensions is abandoned, you should avoid using it. No replacement was suggested.
+2022-12-03 18:50:47 umvc-php-1      | Generating autoload files
+2022-12-03 18:50:49 umvc-php-1      | 64 packages you are using are looking for funding.
+2022-12-03 18:50:49 umvc-php-1      | Use the `composer fund` command to find out more!
+2022-12-03 18:50:49 umvc-php-1      | No security vulnerability advisories found
+2022-12-03 18:50:49 umvc-php-1      | Waiting for database container to be ready...
+2022-12-03 18:50:49 umvc-php-1      | Trying to connect...
+2022-12-03 18:50:49 umvc-php-1      | Connection failed
+2022-12-03 18:50:51 umvc-php-1      | Trying to connect...
+2022-12-03 18:50:51 umvc-php-1      | Connection failed
+2022-12-03 18:50:53 umvc-php-1      | Trying to connect...
+2022-12-03 18:50:53 umvc-php-1      | Connection failed
+2022-12-03 18:50:55 umvc-php-1      | Trying to connect...
+2022-12-03 18:50:55 umvc-php-1      | Connection failed
+2022-12-03 18:50:44 umvc-test-db-1  | [Entrypoint] MySQL Docker Image 8.0.31-1.2.10-server
+2022-12-03 18:50:44 umvc-test-db-1  | [Entrypoint] Initializing database
+2022-12-03 18:50:44 umvc-test-db-1  | 2022-12-03T17:50:44.374219Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-12-03 18:50:44 umvc-test-db-1  | 2022-12-03T17:50:44.374287Z 0 [Warning] [MY-010918] [Server] 'default_authentication_plugin' is deprecated and will be removed in a future release. Please use authentication_policy instead.
+2022-12-03 18:50:44 umvc-test-db-1  | 2022-12-03T17:50:44.374307Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.31) initializing of server in progress as process 17
+2022-12-03 18:50:44 umvc-test-db-1  | 2022-12-03T17:50:44.383487Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-12-03 18:50:44 umvc-test-db-1  | 2022-12-03T17:50:44.903832Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-12-03 18:50:46 umvc-test-db-1  | 2022-12-03T17:50:46.197198Z 6 [Warning] [MY-010453] [Server] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
+2022-12-03 18:50:57 umvc-php-1      | Trying to connect...
+2022-12-03 18:50:57 umvc-php-1      | Connection failed
+2022-12-03 18:50:57 umvc-test-db-1  | [Entrypoint] Database initialized
+2022-12-03 18:50:57 umvc-test-db-1  | 2022-12-03T17:50:57.872025Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-12-03 18:50:57 umvc-test-db-1  | 2022-12-03T17:50:57.873474Z 0 [Warning] [MY-010918] [Server] 'default_authentication_plugin' is deprecated and will be removed in a future release. Please use authentication_policy instead.
+2022-12-03 18:50:57 umvc-test-db-1  | 2022-12-03T17:50:57.873497Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.31) starting as process 66
+2022-12-03 18:50:57 umvc-test-db-1  | 2022-12-03T17:50:57.891407Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-12-03 18:50:58 umvc-test-db-1  | 2022-12-03T17:50:58.065184Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-12-03 18:50:58 umvc-test-db-1  | 2022-12-03T17:50:58.348904Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+2022-12-03 18:50:58 umvc-test-db-1  | 2022-12-03T17:50:58.348947Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
+2022-12-03 18:50:58 umvc-test-db-1  | 2022-12-03T17:50:58.369063Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /var/run/mysqld/mysqlx.sock
+2022-12-03 18:50:58 umvc-test-db-1  | 2022-12-03T17:50:58.369114Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.31'  socket: '/var/lib/mysql/mysql.sock'  port: 0  MySQL Community Server - GPL.
+2022-12-03 18:50:58 umvc-test-db-1  | Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
+2022-12-03 18:50:58 umvc-test-db-1  | Warning: Unable to load '/usr/share/zoneinfo/leapseconds' as time zone. Skipping it.
+2022-12-03 18:50:59 umvc-php-1      | Trying to connect...
+2022-12-03 18:50:59 umvc-php-1      | Connection failed
+2022-12-03 18:50:59 umvc-test-db-1  | Warning: Unable to load '/usr/share/zoneinfo/tzdata.zi' as time zone. Skipping it.
+2022-12-03 18:50:59 umvc-test-db-1  | Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
+2022-12-03 18:50:59 umvc-test-db-1  | Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
+2022-12-03 18:51:00 umvc-test-db-1  |
+2022-12-03 18:51:00 umvc-test-db-1  | [Entrypoint] ignoring /docker-entrypoint-initdb.d/*
+2022-12-03 18:51:00 umvc-test-db-1  |
+2022-12-03 18:51:00 umvc-test-db-1  | 2022-12-03T17:51:00.044822Z 14 [System] [MY-013172] [Server] Received SHUTDOWN from user root. Shutting down mysqld (Version: 8.0.31).
+2022-12-03 18:51:01 umvc-test-db-1  | 2022-12-03T17:51:01.079909Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.0.31)  MySQL Community Server - GPL.
+2022-12-03 18:51:01 umvc-php-1      | Trying to connect...
+2022-12-03 18:51:01 umvc-php-1      | Connection failed
+2022-12-03 18:51:02 umvc-test-db-1  | [Entrypoint] Server shut down
+2022-12-03 18:51:02 umvc-test-db-1  |
+2022-12-03 18:51:02 umvc-test-db-1  | [Entrypoint] MySQL init process done. Ready for start up.
+2022-12-03 18:51:02 umvc-test-db-1  |
+2022-12-03 18:51:02 umvc-test-db-1  | [Entrypoint] Starting MySQL 8.0.31-1.2.10-server
+2022-12-03 18:51:02 umvc-test-db-1  | 2022-12-03T17:51:02.258230Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.
+2022-12-03 18:51:02 umvc-test-db-1  | 2022-12-03T17:51:02.259193Z 0 [Warning] [MY-010918] [Server] 'default_authentication_plugin' is deprecated and will be removed in a future release. Please use authentication_policy instead.
+2022-12-03 18:51:02 umvc-test-db-1  | 2022-12-03T17:51:02.259219Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.31) starting as process 1
+2022-12-03 18:51:02 umvc-test-db-1  | 2022-12-03T17:51:02.265355Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+2022-12-03 18:51:02 umvc-test-db-1  | 2022-12-03T17:51:02.384648Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+2022-12-03 18:51:02 umvc-test-db-1  | 2022-12-03T17:51:02.634322Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+2022-12-03 18:51:02 umvc-test-db-1  | 2022-12-03T17:51:02.634427Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
+2022-12-03 18:51:02 umvc-test-db-1  | 2022-12-03T17:51:02.658248Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/run/mysqld/mysqlx.sock
+2022-12-03 18:51:02 umvc-test-db-1  | 2022-12-03T17:51:02.658314Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.31'  socket: '/var/lib/mysql/mysql.sock'  port: 3306  MySQL Community Server - GPL.
+2022-12-03 18:51:03 umvc-php-1      | Trying to connect...
+2022-12-03 18:51:03 umvc-php-1      | Connected
+2022-12-03 18:51:03 umvc-php-1      | Migrating database
+2022-12-03 18:51:03 umvc-php-1      | The migrate command keeps database changes in sync with source code.
+2022-12-03 18:51:03 umvc-php-1      | Run `php app migrate help` for more details.
+2022-12-03 18:51:03 umvc-php-1      |
+2022-12-03 18:51:03 umvc-php-1      | Creating `migration` table...
+2022-12-03 18:51:03 umvc-php-1      | There are 2 new updates:
+2022-12-03 18:51:03 umvc-php-1      |   - /app/tests/_data/testapp/migrations/m220903_000000_init.sql
+2022-12-03 18:51:03 umvc-php-1      |   - /app/tests/_data/testapp/migrations/m220915_000000_course.sql
+2022-12-03 18:51:04 umvc-php-1      |
+2022-12-03 18:51:04 umvc-php-1      | 2 migrations were applied.
+2022-12-03 18:51:04 umvc-php-1      | Starting apache
+2022-12-03 18:51:04 umvc-php-1      | ---------------
+2022-12-03 18:51:04 umvc-php-1      | Enabling module rewrite.
+2022-12-03 18:51:04 umvc-php-1      | To activate the new configuration, you need to run:
+2022-12-03 18:51:04 umvc-php-1      |   service apache2 restart
+2022-12-03 18:51:04 umvc-php-1      | [Sat Dec 03 18:51:04.233312 2022] [mpm_prefork:notice] [pid 1] AH00163: Apache/2.4.38 (Debian) PHP/7.4.33 configured -- resuming normal operations
+2022-12-03 18:51:04 umvc-php-1      | [Sat Dec 03 18:51:04.233362 2022] [core:notice] [pid 1] AH00094: Command line: 'apache2 -D FOREGROUND'
+```

--- a/tests/unit/AppHelperTest.php
+++ b/tests/unit/AppHelperTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace unit;
+
+use uhi67\umvc\AppHelper;
+
+class AppHelperTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+    
+    protected function _before()
+    {
+    }
+
+    protected function _after()
+    {
+    }
+
+    // tests
+
+	/**
+	 * @dataProvider provWaitFor
+	 * @return void
+	 */
+    public function testWaitFor($timeout, $interval, $length, $success, $attempts, $elapsed)
+    {
+		$start = time();
+		$end = $start + $length;
+	    $a = 0;
+	    $result = AppHelper::waitFor(function() use($end, &$a) {
+			$a++;
+		    return time() >= $end;
+	    }, $timeout, $interval);
+
+		$this->assertEquals($success, $result);
+		$this->assertEquals($attempts, $a);
+		$this->assertEqualsWithDelta($elapsed, time()-$start, 1.0);
+
+    }
+	public function provWaitFor() {
+		return [
+			// $timeout, $interval, $length, $success, $attempts, $elapsed
+			[10, 1, 3, true, 4, 3],
+			[3, 2, 4, false, 2, 3],
+		];
+	}
+}

--- a/tests/unit/AppHelperTest.php
+++ b/tests/unit/AppHelperTest.php
@@ -44,6 +44,8 @@ class AppHelperTest extends \Codeception\Test\Unit
 			// $timeout, $interval, $length, $success, $attempts, $elapsed
 			[10, 1, 3, true, 4, 3],
 			[3, 2, 4, false, 2, 3],
+			[3, 10, 4, false, 1, 3],
+			[0, 0, 4, false, 1, 1],
 		];
 	}
 }

--- a/tests/unit/MigrateTest.php
+++ b/tests/unit/MigrateTest.php
@@ -36,8 +36,6 @@ class MigrateTest extends Unit
 	 */
 	public function testMigrate() {
 		$this->assertInstanceOf(MysqlConnection::class, $this->app->connection);
-		$this->assertTrue(method_exists($this->app->connection, 'getPdo'));
-		$this->assertInstanceOf(\PDO::class, $this->app->connection->pdo);
 		$migrationTable = $this->app->connection->migrationTable ?: 'migration';
 		if($this->app->connection->tableExists($migrationTable)) {
 			// Run migrate/reset command

--- a/tests/unit/MigrateTest.php
+++ b/tests/unit/MigrateTest.php
@@ -6,6 +6,7 @@ use Codeception\Test\Unit;
 use Exception;
 use uhi67\umvc\App;
 use uhi67\umvc\commands\MigrateController;
+use uhi67\umvc\MysqlConnection;
 use UnitTester;
 
 class MigrateTest extends Unit
@@ -34,6 +35,19 @@ class MigrateTest extends Unit
 	 * @throws Exception
 	 */
 	public function testMigrate() {
+		$this->assertInstanceOf(MysqlConnection::class, $this->app->connection);
+		$this->assertTrue(method_exists($this->app->connection, 'getPdo'));
+		$this->assertInstanceOf(\PDO::class, $this->app->connection->pdo);
+		$migrationTable = $this->app->connection->migrationTable ?: 'migration';
+		if($this->app->connection->tableExists($migrationTable)) {
+			// Run migrate/reset command
+			$this->assertEquals( 200, $this->app->runController(MigrateController::class, [], [
+				'action'=>'reset',
+				'confirm'=>'yes',
+				'verbose'=>3,
+			]));
+		}
+		// Run migrate command (default action)
 	    $this->assertEquals( 200, $this->app->runController(MigrateController::class, [], [
 			'confirm'=>'yes',
 		    'verbose'=>3,


### PR DESCRIPTION
Docker entrypoint is using `migrate/wait` command to wait for database container initialization.
Database container initializes slow especially first time if database is not yet created. To repeat the test, delete the database volume. See `tests/docker/readme.md` for example.
Key changes:
- `AppHelper::waitFor()` function fixed;
- Deferred connection of `Connection` (`MysqlConnection`) component. The component does not build the pdo connection while constructing the component, but at the first use. 