### PR TITLE
Feature/localizedrender

### DIFF
--- a/lib/App.php
+++ b/lib/App.php
@@ -351,26 +351,28 @@ class App extends Component {
 	 *
 	 * ### Definitions of localized views:**
 	 *
-	 * - default view: the original view path without localization, e.g 'main/index'
+	 * - source locale: the locale used in the source code and the base language of the translations.
+	 * - default view: the original view path without localization, e.g 'main/index' written in the language and rules of the source locale
 	 * - localized view: the view path with locale code, e.g. 'main/en/index' or 'main/en-GB/index' whichever fits better.
+	 * - source-locale view: the default view or the localized view of the source-locale
 	 * - locale can be an ISO 639-1 language code ('en') optionally extended with a ISO 3166-1-a2 region ('en-GB')
 	 *
 	 * ### Rules for locale and language codes**
 	 *
 	 * - If current locale is 'en-GB', the path with 'en-GB' is preferred, otherwise 'en' is used. No other 'en-*' is used
-	 * - If current locale is 'en', the path with 'en' is used, no any 'en-*' is recognised.
+	 * - If current locale is 'en', the path with 'en' is used, no 'en-*' is recognized.
 	 *
 	 * ### Locale selection
 	 *
-	 * - true: use current locale if the localized view exists, otherwise use the default view
-	 * - false: do not use localized view, even if exists. If the unlocalized view does not exist, an exception occurs.
+	 * - true: use current locale if the localized view exists, otherwise use the default view or source-locale view.
+	 * - false: do not use localized view, even if exists. If the unlocalized (default) view does not exist, an exception occurs.
 	 * - explicit locale: use the specified locale, as defined at 'true' case.
 	 *
 	 * Note: returns an error message rendered as a string on internal rendering errors or Exception
 	 *
 	 * @param string $viewName -- basename of a php view-file in the `views` directory, without extension and without localization code
 	 * @param array $params -- parameters to assign to variables used in the view
-	 * @param string $layout -- the layout applied to this render after the view rendered. If false, no layout will be applied.
+	 * @param string $layout -- the layout applied to the result after the view rendered. If false, no layout will be applied.
 	 * @param array $layoutParams -- optional parameters for the layout view
 	 * @param string|bool|null $locale -- use localized layout selection (ISO 639-1 language / ISO 3166-1-a2 locale), see above
 	 *

--- a/lib/AppHelper.php
+++ b/lib/AppHelper.php
@@ -474,4 +474,19 @@ class AppHelper {
 		return false;
 	}
 
+	/**
+	 * Returns true if path is absolute, false if not (relative).
+	 * Empty string considered as relative.
+	 * Can be user for file síystem and URL paths as well.
+	 * Both Windows and linux file system paths are detected.
+	 * The path itself is not validated, malformed paths can be either absolute or relative.
+	 * Note: Paths beginning with drive letter on Windows but not \\ still considered as absolute.
+	 *
+	 * @param string $path
+	 * @return bool
+	 */
+	public static function pathIsAbsolute(string $path): bool {
+		return preg_match('~^(/|\\\\|[\w]+:)~', $path);
+	}
+
 }

--- a/lib/AppHelper.php
+++ b/lib/AppHelper.php
@@ -477,8 +477,8 @@ class AppHelper {
 	/**
 	 * Returns true if path is absolute, false if not (relative).
 	 * Empty string considered as relative.
-	 * Can be user for file síystem and URL paths as well.
-	 * Both Windows and linux file system paths are detected.
+	 * Can be used for file system and URL paths as well.
+	 * Both Windows and Linux file system paths are detected.
 	 * The path itself is not validated, malformed paths can be either absolute or relative.
 	 * Note: Paths beginning with drive letter on Windows but not \\ still considered as absolute.
 	 *

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -242,6 +242,7 @@ class Controller extends Component
 	 * @param string $viewName
 	 * @param string $locale
 	 * @return string|null
+	 * @throws Exception
 	 */
 	private function localizedView($viewName, $locale) {
 		// Look up view file using full locale

--- a/tests/_data/test-config-template.php
+++ b/tests/_data/test-config-template.php
@@ -37,23 +37,6 @@ return [
             'user' => getenv('DB_USER') ?: "umvc-test",
             'password' => getenv('DB_PASSWORD') ?: "umvc-test",
         ],
-        //---- Authentication module
-//        'auth' => [
-//            \uhi67\umvc\SamlAuth::class,
-//            //---- SAML related configuration values
-//            // Must be set to a secure password
-//            'admin_password' => '...',
-//            // Must be set to a secure random string
-//            'secret_salt' => '...',
-//            // A specific IdP can be configured to login with. If not specified, the discovery service will be called.
-//            'idp' => null,
-//            // URL of the discovery service to be used. If not specified, the internal discovery service will be used with predefined IdPs.
-//            'disco' => null,
-//            // Refers to the proper SAML auth-source config element in the `config/saml/config/authsource.php` file
-//            'authSource' => 'umvc-test',
-//            'idAttribute' => 'eduPersonPrincipalName',
-//            'userModel' => \app\models\User::class, // Must be a Model implementing UserInterface
-//        ],
         // Define the cache used for accelerating database operations. May be omitted in development environment.
         'cache' => [
             // A component definition array must contain a classname and optional initialization values for public properties.

--- a/tests/_data/testapp/views/layouts/rendertestlayout.php
+++ b/tests/_data/testapp/views/layouts/rendertestlayout.php
@@ -1,0 +1,4 @@
+<?php
+/** @var $content */
+?>
+<html><body><?= $content ?></body></html>

--- a/tests/_data/testapp/views/main/_test3.php
+++ b/tests/_data/testapp/views/main/_test3.php
@@ -1,0 +1,1 @@
+<p>Welcome.</p>

--- a/tests/_data/testapp/views/main/hu/rendertest.php
+++ b/tests/_data/testapp/views/main/hu/rendertest.php
@@ -1,0 +1,4 @@
+<?php
+/** @var $name */
+?>
+<h2>Szia, <?= $name ?>!</h2>

--- a/tests/_data/testapp/views/main/hu/rendertest3.php
+++ b/tests/_data/testapp/views/main/hu/rendertest3.php
@@ -1,0 +1,6 @@
+<?php
+/** @var $name */
+/** @var \uhi67\umvc\App $this */
+?>
+<h2>Szia, <?= $name ?>!</h2>
+<?= $this->renderPartial('main/_test3', ['name'=>$name]) ?>

--- a/tests/_data/testapp/views/main/it/_test2.php
+++ b/tests/_data/testapp/views/main/it/_test2.php
@@ -1,0 +1,4 @@
+<?php
+/** @var $name */
+?>
+<p><?= $name ?> italiani</p>

--- a/tests/_data/testapp/views/main/it/rendertest.php
+++ b/tests/_data/testapp/views/main/it/rendertest.php
@@ -1,0 +1,4 @@
+<?php
+/** @var $name */
+?>
+<h2>Ciao, <?= $name ?>!</h2>

--- a/tests/_data/testapp/views/main/rendertest.php
+++ b/tests/_data/testapp/views/main/rendertest.php
@@ -1,1 +1,4 @@
-<h2>Hello, $name!</h2>
+<?php
+/** @var $name */
+?>
+<h2>Hello, <?= $name ?>!</h2>

--- a/tests/_data/testapp/views/main/rendertest.php
+++ b/tests/_data/testapp/views/main/rendertest.php
@@ -1,0 +1,1 @@
+<h2>Hello, $name!</h2>

--- a/tests/_data/testapp/views/main/rendertest2.php
+++ b/tests/_data/testapp/views/main/rendertest2.php
@@ -1,0 +1,6 @@
+<?php
+/** @var $name */
+/** @var \uhi67\umvc\App $this */
+?>
+<h2>Hello, <?= $name ?>!</h2>
+<?= $this->renderPartial('main/_test2', ['name'=>$name]) ?>

--- a/tests/unit/AppHelperTest.php
+++ b/tests/unit/AppHelperTest.php
@@ -48,4 +48,30 @@ class AppHelperTest extends \Codeception\Test\Unit
 			[0, 0, 4, false, 1, 1],
 		];
 	}
+
+	/**
+	 * @dataProvider provPathIsAbsolute
+	 * @return void
+	 */
+	public function testPathIsAbsolute($path, $expected) {
+		$this->assertEquals($expected, AppHelper::pathIsAbsolute($path));
+	}
+	public function provPathIsAbsolute() {
+		return [
+			['.', false],
+			['', false],
+			['../', false],
+			['./any', false],
+			['alma', false],
+			['/', true],
+			['/alma', true],
+			['\\alma', true],
+			['C:\\alma', true],
+			['eee:\\alma', true],
+			['_:\\alma', true],
+			['D:alma', true],
+			['http://alma', true],
+			['mailto:info@umvc.test', true],
+		];
+	}
 }

--- a/tests/unit/AppHelperTest.php
+++ b/tests/unit/AppHelperTest.php
@@ -22,6 +22,7 @@ class AppHelperTest extends \Codeception\Test\Unit
 
 	/**
 	 * @dataProvider provWaitFor
+	 * @group slow
 	 * @return void
 	 */
     public function testWaitFor($timeout, $interval, $length, $success, $attempts, $elapsed)

--- a/tests/unit/AppTest.php
+++ b/tests/unit/AppTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use uhi67\umvc\App;
+
+class AppTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+	/** @var App $app */
+	public $app;
+    
+    protected function _before()
+    {
+	    App::$app->locale = 'hu-HU';
+	    $this->app = App::$app;
+	    require_once dirname(__DIR__).'/_data/testapp/models/User.php';
+    }
+
+    protected function _after()
+    {
+    }
+
+	/**
+	 * @dataProvider provRender
+	 * @return void
+	 * @throws Exception -- only if view path does not exist
+	 */
+	public function testRender($expected, $view, $params=null, $layout=null, $layoutParams=null, $locale=null)
+    {
+	    $this->assertEquals($expected, $this->app->render($view, $params, $layout, $layoutParams, $locale));
+    }
+    public function provRender()
+    {
+	    return [
+			// $expected, $view, $params, $layout, $layoutParams, $locale
+			[null, 'invalid'],
+			['<h2>Hello, $name!</h2>', 'main/rendertest'],
+	    ];
+    }
+}

--- a/tests/unit/AppTest.php
+++ b/tests/unit/AppTest.php
@@ -15,6 +15,8 @@ class AppTest extends \Codeception\Test\Unit
     {
 	    App::$app->locale = 'hu-HU';
 	    $this->app = App::$app;
+		$this->app->layout = 'layouts/rendertestlayout';
+	    $this->app->locale = 'hu-HU';
 	    require_once dirname(__DIR__).'/_data/testapp/models/User.php';
     }
 
@@ -23,20 +25,64 @@ class AppTest extends \Codeception\Test\Unit
     }
 
 	/**
+	 * @dataProvider provLocalizedViewFile
+	 * @throws Exception
+	 */
+	public function testLocalizedViewFile($expected, $view, $locale=null)
+	{
+		$viewPath = $this->app->basePath.'/views';
+		$file = $this->app->localizedViewFile($view, $locale);
+		$this->assertEquals($expected ? $viewPath.'/'.$expected : $expected, $file);
+		if($expected) $this->assertFileExists($file);
+	}
+	public function provLocalizedViewFile()
+	{
+		return [
+			// $expected, $view, $params, $layout, $layoutParams, $locale
+			[null, 'invalid'],
+			['main/rendertest.php', 'main/rendertest'],
+		];
+	}
+
+	/**
 	 * @dataProvider provRender
 	 * @return void
 	 * @throws Exception -- only if view path does not exist
 	 */
 	public function testRender($expected, $view, $params=null, $layout=null, $layoutParams=null, $locale=null)
     {
-	    $this->assertEquals($expected, $this->app->render($view, $params, $layout, $layoutParams, $locale));
+		if(is_a($expected, Exception::class, true)) $this->tester->expectThrowable(Throwable::class, function() {
+			$this->assertEquals($expected, $this->app->render($view, $params, $layout, $layoutParams, $locale));
+		});
+		else {
+			$this->assertEquals($expected, $this->app->render($view, $params, $layout, $layoutParams, $locale));
+		}
     }
     public function provRender()
     {
 	    return [
 			// $expected, $view, $params, $layout, $layoutParams, $locale
+		    // Invalid view name
 			[null, 'invalid'],
-			['<h2>Hello, $name!</h2>', 'main/rendertest'],
+		    // Invalid layout name
+		    [null, 'main/rendertest', null, 'invalid'],
+		    // Render with missing param
+		    [Exception::class, 'main/rendertest', null, null, null, false],
+		    // Normal render with default layout and disabled locale
+			['<html><body><h2>Hello, buddy!</h2></body></html>', 'main/rendertest', ['name'=>'buddy'], null, null, false],
+		    // Normal render without layout with params and with default locale
+		    ['<h2>Szia, haver!</h2>', 'main/rendertest', ['name'=>'haver'], false],
+		    // Normal render without layout and with explicit (undefined) locale
+		    ['<h2>Hello, kompis!</h2>', 'main/rendertest', ['name'=>'kompis'], false, null, 'se'],
+		    // Normal render without layout with params and with explicit locale
+		    ['<h2>Ciao, ragazzi!</h2>', 'main/rendertest', ['name'=>'ragazzi'], false, null, 'it'],
+		    // Normal render without layout with params and with explicit long locale
+		    ['<h2>Ciao, ragazzi!</h2>', 'main/rendertest', ['name'=>'ragazzi'], false, null, 'it-IT'],
+
+		    // View with partial render using explicit locale (main view untranslated, but partial view found localized)
+		    ["<h2>Hello, ragazzi!</h2>\r\n<p>ragazzi italiani</p>", 'main/rendertest2', ['name'=>'ragazzi'], false, null, 'it-IT'],
+		    // View with partial render using explicit locale (main view translated, but partial view not found)
+		    ["<h2>Szia, haver!</h2>\r\n<p>Welcome.</p>", 'main/rendertest3', ['name'=>'haver'], false, null, 'hu'],
 	    ];
     }
 }

--- a/tests/unit/AppTest.php
+++ b/tests/unit/AppTest.php
@@ -38,7 +38,7 @@ class AppTest extends \Codeception\Test\Unit
 	public function provLocalizedViewFile()
 	{
 		return [
-			// $expected, $view, $params, $layout, $layoutParams, $locale
+			// $expected, $view, $locale
 			[null, 'invalid'],
 			['main/rendertest.php', 'main/rendertest'],
 		];


### PR DESCRIPTION
The purpose of this change to ensure that if you render a page using the user-selected locale or any explicit locale, all partial renders (subviews) called from that view use the same locale.
Otherwise the change is backward-compatible.